### PR TITLE
feat(schedule): Swap `speakers` and `takeaways`

### DIFF
--- a/src/app/home/modules/schedule/components/schedule-item-detail/schedule-item-detail.component.html
+++ b/src/app/home/modules/schedule/components/schedule-item-detail/schedule-item-detail.component.html
@@ -15,6 +15,17 @@
 	</section>
 
 	<section
+		*ngIf="item.takeaways">
+		<h3>Talk takeaways</h3>
+
+		<ol>
+			<li *ngFor="let takeaway of item.takeaways">
+				{{takeaway}}
+			</li>
+		</ol>
+	</section>
+
+	<section
 		class="schedule-item-detail__speakers"
 		*ngIf="item.speakers">
 		<h3>Speakers</h3>
@@ -32,16 +43,5 @@
 				</ion-label>
 			</ion-item>
 		</ion-list>
-	</section>
-
-	<section
-		*ngIf="item.takeaways">
-		<h3>Talk takeaways</h3>
-
-		<ol>
-			<li *ngFor="let takeaway of item.takeaways">
-				{{takeaway}}
-			</li>
-		</ol>
 	</section>
 </div>


### PR DESCRIPTION
As suggested by @SamVerschueren I swapped `speakers` and `takeaways` and it looks like this now. Feel free to decline this PR if you prefer the previous implementation. 
![image](https://user-images.githubusercontent.com/17174077/69994561-6a1ae000-154e-11ea-9e74-61f0aa16f7a0.png)
